### PR TITLE
[BUGFIX] Use correct ext_emconf syntax

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF['cacheflow'] = [
+$EM_CONF[$_EXTKEY] = [
     'title' => 'Cacheflow',
     'description' => 'Continuous background refreshing of cached pages.',
     'category' => 'be',


### PR DESCRIPTION
The variable `$_EXTKEY` must not be replaced - this is relevant for extension setups without composer